### PR TITLE
Update explicit to avoid npm deprecation warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "homepage": "https://github.com/martinheidegger/commandico",
   "dependencies": {
     "@hapi/joi": "^15.1.0",
-    "explicit": "^0.1.1",
+    "explicit": "^0.1.3",
     "minimist": "^1.1.1"
   },
   "devDependencies": {


### PR DESCRIPTION
This is the continuation of #2 to hopefully shut npm up _for real_ this time. 😅 